### PR TITLE
Fix trailing comma in parsed version numbers.

### DIFF
--- a/npm2tgz
+++ b/npm2tgz
@@ -66,7 +66,7 @@ mkdir -p $PKG
 
 DESTDIR=$PKG npm install -g $PRGNAM
 
-VERSION=$(grep -i "\"version\": \"\(.*\)\"" $PKG${NPMROOT}/$PRGNAM/package.json | sed 's|^[ ]*"version": "\(.*\)"|\1|g')
+VERSION=$(grep -io "\"version\": \"\(.*\)\"" $PKG${NPMROOT}/$PRGNAM/package.json | sed 's|^[ ]*"version": "\(.*\)"|\1|g')
 DESCRIPTION=$(grep -i "\"description\": \"\(.*\)\"," $PKG${NPMROOT}/$PRGNAM/package.json | sed 's|^[ ]*"description": "\(.*\)",$|\1|g')
 HOMEPAGE=$(grep -i "\"homepage\": \"\(.*\)\"," $PKG${NPMROOT}/$PRGNAM/package.json | sed 's|^[ ]*"homepage": "\(.*\)",$|\1|g')
 


### PR DESCRIPTION
If the version number line in package.json ended with a comma, it would get included in the output from `grep` (and not removed by `sed`), resulting in packages like `babel-cli-6.16.0,-npmjs-1SBo.txz`.

Use the `-o` flag so only the matching part is printed.
