### PR TITLE
Fix complaints from shellcheck

### DIFF
--- a/npm2tgz
+++ b/npm2tgz
@@ -42,7 +42,7 @@ NPMBIN=${NPMBIN:=/usr/bin/npm}
 NPMROOT=${NPMROOT:-$($NPMBIN -g root)}
 
 [ ! -x "$NPMBIN" ] && echo "npm missing" && exit 1
-if [ "x$1" == "x" ] || [ "x$1" == "x--help" ] || [ "x$1" == "x-h" ]; then
+if [ $# -eq 0 ] || [ "$1" = --help ] || [ "$1" = -h ]; then
     echo "$0 generates a Slackware compatible package from a node module"
     echo "  usage: <OPTIONS> $0 <modules_name>"
     echo "  The resulting package is located under $OUTPUT"
@@ -95,5 +95,5 @@ $PRGNAM: $HOMEPAGE
 $PRGNAM:
 EOF
 
-cd "$PKG"
+cd "$PKG" &&
 makepkg -l y -c n "$OUTPUT/$PRGNAM-$(echo "$VERSION" | tr - .)-$ARCH-$BUILD$TAG.txz"


### PR DESCRIPTION
Tested in POSIX-compliant (I think?) dash-0.5.12.

List of complaints fixed:

```
In npm2tgz line 45:
if [ "x$1" == "x" ] || [ "x$1" == "x--help" ] || [ "x$1" == "x-h" ]; then
     ^---^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.
           ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.
                         ^---^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.
                               ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.
                                                   ^---^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.
                                                         ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

Did you mean:
if [ "$1" == "" ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then

In npm2tgz line 98:
cd "$PKG"
^-------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean:
cd "$PKG" || exit

For more information:
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC3014 -- In POSIX sh, == in place of = is ...
  https://www.shellcheck.net/wiki/SC2268 -- Avoid x-prefix in comparisons as ...
```